### PR TITLE
Reduce tool header titles from h1 to h2

### DIFF
--- a/assets/tools/bldc-frequency-calculator.js
+++ b/assets/tools/bldc-frequency-calculator.js
@@ -340,7 +340,7 @@
     return h("div", null,
 
       // === TITLE ===
-      h("h1", { className: "bc-title" }, "BLDC Motor Frequency Calculator"),
+      h("h2", { className: "bc-title" }, "BLDC Motor Frequency Calculator"),
 
       // === INPUT SECTION ===
       h("div", { className: "bc-inputs" },

--- a/assets/tools/signal-composition.js
+++ b/assets/tools/signal-composition.js
@@ -284,7 +284,7 @@
 
         // Single header row: title left, controls right (wraps to two rows on mobile)
         h("div", { className: "sd-header-row" },
-          h("h1", { className: "sd-title" }, "Composite Signal"),
+          h("h2", { className: "sd-title" }, "Composite Signal"),
           h("div", { className: "sd-controls" },
             h("button", {
               onClick: function () { setShowTraces(!showTraces); },


### PR DESCRIPTION
## Summary
- Changed BLDC frequency calculator title from h1 to h2
- Changed signal composition title from h1 to h2

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>