### PR TITLE
Remove z-index from signal composition sticky header

### DIFF
--- a/assets/tools/signal-composition.css
+++ b/assets/tools/signal-composition.css
@@ -28,7 +28,6 @@
 #signal-demo .sd-composite {
   position: sticky;
   top: 0;
-  z-index: 10;
   background: #0b0e14;
   padding: 16px 20px 12px;
   box-shadow: 0 4px 20px rgba(0,0,0,0.5);


### PR DESCRIPTION
## Summary
- Removed z-index: 10 from .sd-composite sticky header so search overlay renders on top

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>