### PR TITLE
Fix signal composition rounded corners

### DIFF
--- a/assets/tools/signal-composition.css
+++ b/assets/tools/signal-composition.css
@@ -5,6 +5,7 @@
   color: rgba(255,255,255,0.7);
   background: #0b0e14;
   border-radius: 10px;
+  overflow: hidden;
   margin: 1.5em 0;
 }
 


### PR DESCRIPTION
## Summary
- Added overflow: hidden to #signal-demo container so children are clipped to the rounded corners

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>