### PR TITLE
Add custom RPM input to BLDC calculator

### DIFF
--- a/assets/tools/bldc-frequency-calculator.js
+++ b/assets/tools/bldc-frequency-calculator.js
@@ -364,18 +364,37 @@
           onChange: setSlots,
         }),
 
-        h(ToggleGroup, {
-          label: "RPM",
-          options: [
-            { value: 16.667, label: "16⅔" },
-            { value: 22.5, label: "22½" },
-            { value: 33.333, label: "33⅓" },
-            { value: 45, label: "45" },
-            { value: 78, label: "78" },
-          ],
-          value: rpm,
-          onChange: setRpm,
-        }),
+        h("div", { className: "bc-toggle-row" },
+          h("label", { className: "bc-input-label" }, "RPM"),
+          h("div", { className: "bc-toggle-group" },
+            [
+              { value: 16.667, label: "16⅔" },
+              { value: 22.5, label: "22½" },
+              { value: 33.333, label: "33⅓" },
+              { value: 45, label: "45" },
+              { value: 78, label: "78" },
+            ].map(function (opt) {
+              var isActive = opt.value === rpm;
+              return h("button", {
+                key: opt.value,
+                className: "bc-toggle-btn" + (isActive ? " bc-toggle-active" : ""),
+                onClick: function () { setRpm(opt.value); },
+              }, opt.label);
+            })
+          ),
+          h("input", {
+            type: "number",
+            min: 0.1,
+            max: 10000,
+            step: 0.001,
+            value: rpm,
+            onChange: function (e) {
+              var val = parseFloat(e.target.value);
+              if (!isNaN(val)) setRpm(val);
+            },
+            className: "bc-number-input",
+          })
+        ),
 
         h(ToggleGroup, {
           label: "Phases",


### PR DESCRIPTION
## Summary
- Added numeric input field alongside RPM preset toggle buttons
- Allows entering any custom RPM value

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>