### PR TITLE
Fix RPM input wrapping at all screen sizes

### DIFF
--- a/assets/tools/bldc-frequency-calculator.css
+++ b/assets/tools/bldc-frequency-calculator.css
@@ -140,6 +140,7 @@
   align-items: center;
   gap: 12px;
   flex: 1;
+  flex-wrap: wrap;
 }
 
 #bldc-calc .bc-toggle-group {
@@ -306,10 +307,6 @@
   #bldc-calc .bc-slider::-webkit-slider-thumb {
     width: 22px;
     height: 22px;
-  }
-
-  #bldc-calc .bc-rpm-controls {
-    flex-wrap: wrap;
   }
 
   #bldc-calc .bc-panel-header {


### PR DESCRIPTION
## Summary
- Moved flex-wrap: wrap to base styles so RPM input wraps consistently at any width

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>