### PR TITLE
Fix label width, add custom RPM input

### DIFF
--- a/assets/tools/bldc-frequency-calculator.css
+++ b/assets/tools/bldc-frequency-calculator.css
@@ -54,7 +54,7 @@
 #bldc-calc .bc-input-label {
   font-size: 11px;
   color: rgba(255,255,255,0.5);
-  width: 70px;
+  width: 75px;
   flex-shrink: 0;
 }
 
@@ -130,7 +130,21 @@
 #bldc-calc .bc-toggle-group {
   display: flex;
   gap: 6px;
-  flex: 1;
+}
+
+/* RPM row with custom input */
+#bldc-calc .bc-rpm-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 10px;
+}
+
+#bldc-calc .bc-rpm-controls {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
 }
 
 #bldc-calc .bc-toggle-btn {
@@ -273,10 +287,6 @@
 
   #bldc-calc .bc-inputs {
     padding: 12px 14px;
-  }
-
-  #bldc-calc .bc-input-label {
-    width: 60px;
   }
 
   #bldc-calc .bc-input-value {

--- a/assets/tools/bldc-frequency-calculator.js
+++ b/assets/tools/bldc-frequency-calculator.js
@@ -364,18 +364,39 @@
           onChange: setSlots,
         }),
 
-        h(ToggleGroup, {
-          label: "RPM",
-          options: [
-            { value: 16.667, label: "16⅔" },
-            { value: 22.5, label: "22½" },
-            { value: 33.333, label: "33⅓" },
-            { value: 45, label: "45" },
-            { value: 78, label: "78" },
-          ],
-          value: rpm,
-          onChange: setRpm,
-        }),
+        h("div", { className: "bc-rpm-row" },
+          h("label", { className: "bc-input-label" }, "RPM"),
+          h("div", { className: "bc-rpm-controls" },
+            h("div", { className: "bc-toggle-group" },
+              [
+                { value: 16.667, label: "16⅔" },
+                { value: 22.5, label: "22½" },
+                { value: 33.333, label: "33⅓" },
+                { value: 45, label: "45" },
+                { value: 78, label: "78" },
+              ].map(function (opt) {
+                var isActive = opt.value === rpm;
+                return h("button", {
+                  key: opt.value,
+                  className: "bc-toggle-btn" + (isActive ? " bc-toggle-active" : ""),
+                  onClick: function () { setRpm(opt.value); },
+                }, opt.label);
+              })
+            ),
+            h("input", {
+              type: "number",
+              min: 0.1,
+              max: 10000,
+              step: 0.001,
+              value: rpm,
+              onChange: function (e) {
+                var val = parseFloat(e.target.value);
+                if (!isNaN(val)) setRpm(val);
+              },
+              className: "bc-number-input",
+            })
+          )
+        ),
 
         h(ToggleGroup, {
           label: "Phases",


### PR DESCRIPTION
## Summary
- Fixed Slots/Coils label wrapping caused by Just the Docs' overflow-wrap: break-word
- Added custom RPM number input after preset toggle buttons
- Input wraps naturally on narrow screens via flex-wrap

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>