### PR TITLE
Fix CI: add jekyll-redirect-from to Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,6 +45,8 @@ GEM
       webrick (~> 1.7)
     jekyll-include-cache (0.2.1)
       jekyll (>= 3.7, < 5.0)
+    jekyll-redirect-from (0.16.0)
+      jekyll (>= 3.3, < 5.0)
     jekyll-sass-converter (3.1.0)
       sass-embedded (~> 1.75)
     jekyll-seo-tag (2.8.0)
@@ -93,6 +95,7 @@ PLATFORMS
 
 DEPENDENCIES
   jekyll (~> 4.4.1)
+  jekyll-redirect-from
   just-the-docs (= 0.12.0)
 
 BUNDLED WITH


### PR DESCRIPTION
## Summary
- Adds `jekyll-redirect-from` gem (0.16.0) to Gemfile.lock so bundler in frozen/deployment mode can resolve it
- Previous commit added the gem to Gemfile and _config.yml plugins but missed the lockfile

## Test plan
- [ ] CI build passes
- [ ] Redirects from old `/docs/` paths work

🤖 Generated with [Claude Code](https://claude.com/claude-code)