### PR TITLE
Fix toggle button overflow on mobile

### DIFF
--- a/assets/tools/motor-frequency-calculator.css
+++ b/assets/tools/motor-frequency-calculator.css
@@ -130,6 +130,7 @@
 #bldc-calc .bc-toggle-group {
   display: flex;
   gap: 6px;
+  flex-wrap: wrap;
 }
 
 /* RPM row with custom input */


### PR DESCRIPTION
## Summary
- Adds flex-wrap to toggle button groups so they wrap on narrow screens instead of overflowing

## Test plan
- [ ] Type toggle (4 buttons) wraps properly on mobile
- [ ] Other toggle rows (Phases, Drive, Motor) unaffected on desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)