### PR TITLE
Replace Adobe PDF viewer with native inline embed

### DIFF
--- a/assets/tools/pdf-embed.js
+++ b/assets/tools/pdf-embed.js
@@ -1,0 +1,72 @@
+import * as pdfjsLib from "https://cdnjs.cloudflare.com/ajax/libs/pdf.js/4.9.155/pdf.min.mjs";
+
+pdfjsLib.GlobalWorkerOptions.workerSrc =
+  "https://cdnjs.cloudflare.com/ajax/libs/pdf.js/4.9.155/pdf.worker.min.mjs";
+
+function embedPDF(container) {
+  var url = container.getAttribute("data-pdf-url");
+  if (!url) return;
+
+  // Check for page hash in the main URL
+  var pageFromHash = null;
+  var hashMatch = window.location.hash.match(/^#page=(\d+)/);
+  if (hashMatch) {
+    pageFromHash = parseInt(hashMatch[1], 10);
+  }
+
+  var loading = document.createElement("div");
+  loading.textContent = "Loading PDF\u2026";
+  loading.style.cssText = "padding:20px;color:rgba(255,255,255,0.5);font-size:14px;";
+  container.appendChild(loading);
+
+  pdfjsLib.getDocument(url).promise.then(function (pdf) {
+    pdf.getPage(1).then(function (page) {
+      var viewport = page.getViewport({ scale: 1 });
+      var aspectRatio = viewport.height / viewport.width;
+      var totalPages = pdf.numPages;
+
+      container.removeChild(loading);
+
+      // Create iframe with browser's native PDF renderer
+      var iframe = document.createElement("iframe");
+      var pdfSrc = url;
+      if (pageFromHash) {
+        pdfSrc += "#page=" + pageFromHash;
+      }
+      iframe.src = pdfSrc;
+      iframe.style.cssText = "width:100%;border:none;display:block;overflow:hidden;";
+
+      function setHeight() {
+        var width = container.clientWidth;
+        var pageHeight = width * aspectRatio;
+        var totalHeight = pageHeight * totalPages;
+        iframe.style.height = Math.ceil(totalHeight) + "px";
+      }
+
+      container.appendChild(iframe);
+      setHeight();
+
+      // Download link
+      var dl = document.createElement("a");
+      dl.href = url;
+      dl.download = "";
+      dl.textContent = "Download PDF";
+      dl.style.cssText = "display:inline-block;margin-top:8px;font-size:13px;color:#00e5ff;text-decoration:none;";
+      container.appendChild(dl);
+
+      window.addEventListener("resize", setHeight);
+    });
+  }).catch(function (err) {
+    container.removeChild(loading);
+    var errMsg = document.createElement("div");
+    errMsg.textContent = "Failed to load PDF: " + err.message;
+    errMsg.style.cssText = "padding:20px;color:#ff4444;font-size:14px;";
+    container.appendChild(errMsg);
+  });
+}
+
+// Initialize all PDF embeds on the page
+var containers = document.querySelectorAll(".pdf-embed");
+for (var i = 0; i < containers.length; i++) {
+  embedPDF(containers[i]);
+}

--- a/test-records/CBS/CTC.md
+++ b/test-records/CBS/CTC.md
@@ -7,16 +7,6 @@ redirect_from:
   - "/docs/test-records/CBS/CTC.html"
 ---
 
-<div id="adobe-dc-view" style="height: 80vh;">
-	<script src="https://acrobatservices.adobe.com/view-sdk/viewer.js"></script>
-	<script type="text/javascript">
-		document.addEventListener("adobe_dc_view_sdk.ready", function(){ 
-			var adobeDCView = new AdobeDC.View({clientId: "5aca0821dfc443928ce227808de9010e", divId: "adobe-dc-view"});
-			adobeDCView.previewFile({
-				content:{location: {url: "/assets/pdfs/CBS Pro Series Test Records.pdf"}},
-				metaData:{fileName: "CBS Pro Series Test Records.pdf"}
-			}, {defaultViewMode: "FIT_WIDTH", showAnnotationTools: false});
-		});
-	</script>
-	<br class="clear"/>
-</div>
+<div class="pdf-embed" data-pdf-url="{{ '/assets/pdfs/CBS Pro Series Test Records.pdf' | relative_url }}"></div>
+
+<script type="module" src="{{ '/assets/tools/pdf-embed.js' | relative_url }}"></script>


### PR DESCRIPTION
## Summary
- Replaces Adobe Acrobat viewer SDK with browser-native PDF rendering on CBS test records page
- Uses pdf.js (ES module) only to measure PDF page dimensions, then creates a full-height iframe
- Browser's native PDF renderer displays the document — no third-party viewer
- PDF scrolls inline with the page, no nested scrollbar
- Supports `#page=N` URL parameter for deep linking to specific pages
- Includes download link below the PDF

## Test plan
- [ ] CBS test records page shows 4-page PDF inline without nested scroll
- [ ] PDF scrolls with the page naturally
- [ ] `#page=3` in URL navigates to page 3
- [ ] Download link works
- [ ] Responsive on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)