### PR TITLE
Fix PDF embed: render to canvas instead of iframe

### DIFF
--- a/assets/tools/pdf-embed.js
+++ b/assets/tools/pdf-embed.js
@@ -7,55 +7,63 @@ function embedPDF(container) {
   var url = container.getAttribute("data-pdf-url");
   if (!url) return;
 
-  // Check for page hash in the main URL
-  var pageFromHash = null;
-  var hashMatch = window.location.hash.match(/^#page=(\d+)/);
-  if (hashMatch) {
-    pageFromHash = parseInt(hashMatch[1], 10);
-  }
-
   var loading = document.createElement("div");
   loading.textContent = "Loading PDF\u2026";
   loading.style.cssText = "padding:20px;color:rgba(255,255,255,0.5);font-size:14px;";
   container.appendChild(loading);
 
   pdfjsLib.getDocument(url).promise.then(function (pdf) {
-    pdf.getPage(1).then(function (page) {
-      var viewport = page.getViewport({ scale: 1 });
-      var aspectRatio = viewport.height / viewport.width;
-      var totalPages = pdf.numPages;
+    container.removeChild(loading);
 
-      container.removeChild(loading);
+    // Download link at top
+    var dl = document.createElement("a");
+    dl.href = url;
+    dl.download = "";
+    dl.textContent = "Download PDF (" + pdf.numPages + " pages)";
+    dl.style.cssText = "display:inline-block;margin-bottom:12px;font-size:13px;color:#00e5ff;text-decoration:none;";
+    container.appendChild(dl);
 
-      // Create iframe with browser's native PDF renderer
-      var iframe = document.createElement("iframe");
-      var pdfSrc = url;
-      if (pageFromHash) {
-        pdfSrc += "#page=" + pageFromHash;
-      }
-      iframe.src = pdfSrc;
-      iframe.style.cssText = "width:100%;border:none;display:block;overflow:hidden;";
+    // Render each page to a canvas
+    var renderPage = function (pageNum) {
+      pdf.getPage(pageNum).then(function (page) {
+        var containerWidth = container.clientWidth;
+        var unscaledViewport = page.getViewport({ scale: 1 });
+        var scale = containerWidth / unscaledViewport.width;
+        // Use 2x scale for sharp rendering on retina, clamped to CSS size
+        var renderScale = scale * (window.devicePixelRatio || 1);
+        var viewport = page.getViewport({ scale: renderScale });
+        var cssViewport = page.getViewport({ scale: scale });
 
-      function setHeight() {
-        var width = container.clientWidth;
-        var pageHeight = width * aspectRatio;
-        var totalHeight = pageHeight * totalPages;
-        iframe.style.height = Math.ceil(totalHeight) + "px";
-      }
+        var canvas = document.createElement("canvas");
+        canvas.width = viewport.width;
+        canvas.height = viewport.height;
+        canvas.style.cssText = "width:100%;height:auto;display:block;margin-bottom:2px;";
+        canvas.id = "pdf-page-" + pageNum;
+        container.appendChild(canvas);
 
-      container.appendChild(iframe);
-      setHeight();
+        var ctx = canvas.getContext("2d");
+        page.render({ canvasContext: ctx, viewport: viewport });
 
-      // Download link
-      var dl = document.createElement("a");
-      dl.href = url;
-      dl.download = "";
-      dl.textContent = "Download PDF";
-      dl.style.cssText = "display:inline-block;margin-top:8px;font-size:13px;color:#00e5ff;text-decoration:none;";
-      container.appendChild(dl);
+        if (pageNum < pdf.numPages) {
+          renderPage(pageNum + 1);
+        }
+      });
+    };
 
-      window.addEventListener("resize", setHeight);
-    });
+    renderPage(1);
+
+    // Handle #page=N scrolling after all pages rendered
+    var hashMatch = window.location.hash.match(/^#page=(\d+)/);
+    if (hashMatch) {
+      var targetPage = parseInt(hashMatch[1], 10);
+      // Wait for pages to render, then scroll
+      setTimeout(function () {
+        var target = document.getElementById("pdf-page-" + targetPage);
+        if (target) {
+          target.scrollIntoView({ behavior: "smooth" });
+        }
+      }, 1000);
+    }
   }).catch(function (err) {
     container.removeChild(loading);
     var errMsg = document.createElement("div");


### PR DESCRIPTION
## Summary
- Renders PDF pages directly to canvas elements instead of iframe
- Eliminates browser PDF viewer chrome (toolbar, thumbnail sidebar)
- Eliminates height miscalculation issues
- Retina-aware rendering (2x pixel density)
- Pages scroll inline with page content naturally
- Supports #page=N deep linking

## Test plan
- [ ] CBS test records page shows all 4 pages inline without any viewer UI
- [ ] Pages are crisp on retina displays
- [ ] No nested scrollbar
- [ ] Download link works

🤖 Generated with [Claude Code](https://claude.com/claude-code)