### PR TITLE
Fast PDF deep linking: render target page first

### DIFF
--- a/assets/tools/pdf-embed.js
+++ b/assets/tools/pdf-embed.js
@@ -3,6 +3,26 @@ import * as pdfjsLib from "https://cdnjs.cloudflare.com/ajax/libs/pdf.js/4.9.155
 pdfjsLib.GlobalWorkerOptions.workerSrc =
   "https://cdnjs.cloudflare.com/ajax/libs/pdf.js/4.9.155/pdf.worker.min.mjs";
 
+function renderPageToCanvas(pdf, pageNum, container) {
+  return pdf.getPage(pageNum).then(function (page) {
+    var containerWidth = container.clientWidth;
+    var unscaledViewport = page.getViewport({ scale: 1 });
+    var scale = containerWidth / unscaledViewport.width;
+    var renderScale = scale * (window.devicePixelRatio || 1);
+    var viewport = page.getViewport({ scale: renderScale });
+
+    // Find the placeholder and replace it
+    var placeholder = document.getElementById("pdf-page-" + pageNum);
+    placeholder.width = viewport.width;
+    placeholder.height = viewport.height;
+
+    var ctx = placeholder.getContext("2d");
+    return page.render({ canvasContext: ctx, viewport: viewport }).promise.then(function () {
+      return placeholder;
+    });
+  });
+}
+
 function embedPDF(container) {
   var url = container.getAttribute("data-pdf-url");
   if (!url) return;
@@ -27,40 +47,37 @@ function embedPDF(container) {
     var targetPage = null;
     var hashMatch = window.location.hash.match(/^#page=(\d+)/);
     if (hashMatch) {
-      targetPage = parseInt(hashMatch[1], 10);
+      targetPage = Math.min(Math.max(parseInt(hashMatch[1], 10), 1), pdf.numPages);
     }
 
-    // Render each page to a canvas
-    var renderPage = function (pageNum) {
-      pdf.getPage(pageNum).then(function (page) {
-        var containerWidth = container.clientWidth;
-        var unscaledViewport = page.getViewport({ scale: 1 });
-        var scale = containerWidth / unscaledViewport.width;
-        var renderScale = scale * (window.devicePixelRatio || 1);
-        var viewport = page.getViewport({ scale: renderScale });
+    // Get first page to determine aspect ratio for placeholders
+    pdf.getPage(1).then(function (firstPage) {
+      var unscaledViewport = firstPage.getViewport({ scale: 1 });
+      var containerWidth = container.clientWidth;
+      var scale = containerWidth / unscaledViewport.width;
+      var cssHeight = Math.ceil(unscaledViewport.height * scale);
 
+      // Create all canvas placeholders up front with correct dimensions
+      for (var i = 1; i <= pdf.numPages; i++) {
         var canvas = document.createElement("canvas");
-        canvas.width = viewport.width;
-        canvas.height = viewport.height;
-        canvas.style.cssText = "width:100%;height:auto;display:block;margin-bottom:2px;";
-        canvas.id = "pdf-page-" + pageNum;
+        canvas.id = "pdf-page-" + i;
+        canvas.style.cssText = "width:100%;height:" + cssHeight + "px;display:block;margin-bottom:2px;background:#f5f5f5;";
         container.appendChild(canvas);
+      }
 
-        var ctx = canvas.getContext("2d");
-        page.render({ canvasContext: ctx, viewport: viewport }).promise.then(function () {
-          // Scroll to target page once it's rendered
-          if (targetPage === pageNum) {
-            canvas.scrollIntoView({ behavior: "smooth" });
-          }
+      // Render target page first if specified, then scroll instantly
+      if (targetPage) {
+        renderPageToCanvas(pdf, targetPage, container).then(function (canvas) {
+          canvas.scrollIntoView({ behavior: "instant" });
 
-          if (pageNum < pdf.numPages) {
-            renderPage(pageNum + 1);
-          }
+          // Render remaining pages in order
+          renderRemaining(pdf, container, targetPage);
         });
-      });
-    };
-
-    renderPage(1);
+      } else {
+        // No target — render sequentially from page 1
+        renderSequential(pdf, container, 1);
+      }
+    });
   }).catch(function (err) {
     container.removeChild(loading);
     var errMsg = document.createElement("div");
@@ -68,6 +85,30 @@ function embedPDF(container) {
     errMsg.style.cssText = "padding:20px;color:#ff4444;font-size:14px;";
     container.appendChild(errMsg);
   });
+}
+
+function renderSequential(pdf, container, pageNum) {
+  if (pageNum > pdf.numPages) return;
+  renderPageToCanvas(pdf, pageNum, container).then(function () {
+    renderSequential(pdf, container, pageNum + 1);
+  });
+}
+
+function renderRemaining(pdf, container, skip) {
+  // Render all pages except the one already rendered, in order
+  var pages = [];
+  for (var i = 1; i <= pdf.numPages; i++) {
+    if (i !== skip) pages.push(i);
+  }
+  var idx = 0;
+  function next() {
+    if (idx >= pages.length) return;
+    renderPageToCanvas(pdf, pages[idx], container).then(function () {
+      idx++;
+      next();
+    });
+  }
+  next();
 }
 
 // Initialize all PDF embeds on the page


### PR DESCRIPTION
## Summary
- Creates all canvas placeholders up front with correct dimensions
- Renders the target page first, scrolls to it instantly
- Remaining pages render in the background after
- No waiting for pages 1 through N-1 to render before seeing the target

## Test plan
- [ ] `#page=3` shows page 3 immediately
- [ ] Normal load without hash renders pages 1-N in order
- [ ] Placeholders have correct size before rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)