### PR TITLE
Replace Adobe PDF viewer on all brochure and manual pages

### DIFF
--- a/brochures/Technics/Technics_EPA-500_System.md
+++ b/brochures/Technics/Technics_EPA-500_System.md
@@ -8,16 +8,6 @@ redirect_from:
   - "/docs/brochures/Technics/Technics_EPA-500_System.html"
 ---
 
-<div id="adobe-dc-view" style="height: 80vh;">
-	<script src="https://acrobatservices.adobe.com/view-sdk/viewer.js"></script>
-	<script type="text/javascript">
-		document.addEventListener("adobe_dc_view_sdk.ready", function(){ 
-			var adobeDCView = new AdobeDC.View({clientId: "5aca0821dfc443928ce227808de9010e", divId: "adobe-dc-view"});
-			adobeDCView.previewFile({
-				content:{location: {url: "/assets/pdfs/Technics_EPA-500_System.pdf"}},
-				metaData:{fileName: "Technics_EPA-500_System.pdf"}
-			}, {defaultViewMode: "FIT_WIDTH", showAnnotationTools: false});
-		});
-	</script>
-	<br class="clear"/>
-</div>
+<div class="pdf-embed" data-pdf-url="{{ '/assets/pdfs/Technics_EPA-500_System.pdf' | relative_url }}"></div>
+
+<script type="module" src="{{ '/assets/js/pdf-embed.js' | relative_url }}"></script>

--- a/brochures/Technics/Technics_NewProducts_10-1980.md
+++ b/brochures/Technics/Technics_NewProducts_10-1980.md
@@ -8,16 +8,6 @@ redirect_from:
   - "/docs/brochures/Technics/Technics_NewProducts_10-1980.html"
 ---
 
-<div id="adobe-dc-view" style="height: 80vh;">
-	<script src="https://acrobatservices.adobe.com/view-sdk/viewer.js"></script>
-	<script type="text/javascript">
-		document.addEventListener("adobe_dc_view_sdk.ready", function(){ 
-			var adobeDCView = new AdobeDC.View({clientId: "5aca0821dfc443928ce227808de9010e", divId: "adobe-dc-view"});
-			adobeDCView.previewFile({
-				content:{location: {url: "/assets/pdfs/Technics_NP10-1980.pdf"}},
-				metaData:{fileName: "Technics_NP10-1980.pdf"}
-			}, {defaultViewMode: "FIT_WIDTH", showAnnotationTools: false});
-		});
-	</script>
-	<br class="clear"/>
-</div>
+<div class="pdf-embed" data-pdf-url="{{ '/assets/pdfs/Technics_NP10-1980.pdf' | relative_url }}"></div>
+
+<script type="module" src="{{ '/assets/js/pdf-embed.js' | relative_url }}"></script>

--- a/brochures/Technics/Technics_NewProducts_10-1982-1.md
+++ b/brochures/Technics/Technics_NewProducts_10-1982-1.md
@@ -8,16 +8,6 @@ redirect_from:
   - "/docs/brochures/Technics/Technics_NewProducts_10-1982-1.html"
 ---
 
-<div id="adobe-dc-view" style="height: 80vh;">
-	<script src="https://acrobatservices.adobe.com/view-sdk/viewer.js"></script>
-	<script type="text/javascript">
-		document.addEventListener("adobe_dc_view_sdk.ready", function(){ 
-			var adobeDCView = new AdobeDC.View({clientId: "5aca0821dfc443928ce227808de9010e", divId: "adobe-dc-view"});
-			adobeDCView.previewFile({
-				content:{location: {url: "/assets/pdfs/Technics_NP10-1982_1.pdf"}},
-				metaData:{fileName: "Technics_NP10-1982_1.pdf"}
-			}, {defaultViewMode: "FIT_WIDTH", showAnnotationTools: false});
-		});
-	</script>
-	<br class="clear"/>
-</div>
+<div class="pdf-embed" data-pdf-url="{{ '/assets/pdfs/Technics_NP10-1982_1.pdf' | relative_url }}"></div>
+
+<script type="module" src="{{ '/assets/js/pdf-embed.js' | relative_url }}"></script>

--- a/brochures/Technics/Technics_NewProducts_10-1982-2.md
+++ b/brochures/Technics/Technics_NewProducts_10-1982-2.md
@@ -8,16 +8,6 @@ redirect_from:
   - "/docs/brochures/Technics/Technics_NewProducts_10-1982-2.html"
 ---
 
-<div id="adobe-dc-view" style="height: 80vh;">
-	<script src="https://acrobatservices.adobe.com/view-sdk/viewer.js"></script>
-	<script type="text/javascript">
-		document.addEventListener("adobe_dc_view_sdk.ready", function(){ 
-			var adobeDCView = new AdobeDC.View({clientId: "5aca0821dfc443928ce227808de9010e", divId: "adobe-dc-view"});
-			adobeDCView.previewFile({
-				content:{location: {url: "/assets/pdfs/Technics_NP10-1982_2.pdf"}},
-				metaData:{fileName: "Technics_NP10-1982_2.pdf"}
-			}, {defaultViewMode: "FIT_WIDTH", showAnnotationTools: false});
-		});
-	</script>
-	<br class="clear"/>
-</div>
+<div class="pdf-embed" data-pdf-url="{{ '/assets/pdfs/Technics_NP10-1982_2.pdf' | relative_url }}"></div>
+
+<script type="module" src="{{ '/assets/js/pdf-embed.js' | relative_url }}"></script>

--- a/brochures/Technics/Technics_NewProducts_4-1979.md
+++ b/brochures/Technics/Technics_NewProducts_4-1979.md
@@ -8,16 +8,6 @@ redirect_from:
   - "/docs/brochures/Technics/Technics_NewProducts_4-1979.html"
 ---
 
-<div id="adobe-dc-view" style="height: 80vh;">
-	<script src="https://acrobatservices.adobe.com/view-sdk/viewer.js"></script>
-	<script type="text/javascript">
-		document.addEventListener("adobe_dc_view_sdk.ready", function(){ 
-			var adobeDCView = new AdobeDC.View({clientId: "5aca0821dfc443928ce227808de9010e", divId: "adobe-dc-view"});
-			adobeDCView.previewFile({
-				content:{location: {url: "/assets/pdfs/Technics_NP4-1979.pdf"}},
-				metaData:{fileName: "Technics_NP4-1979.pdf"}
-			}, {defaultViewMode: "FIT_WIDTH", showAnnotationTools: false});
-		});
-	</script>
-	<br class="clear"/>
-</div>
+<div class="pdf-embed" data-pdf-url="{{ '/assets/pdfs/Technics_NP4-1979.pdf' | relative_url }}"></div>
+
+<script type="module" src="{{ '/assets/js/pdf-embed.js' | relative_url }}"></script>

--- a/brochures/Technics/Technics_NewProducts_8-1980.md
+++ b/brochures/Technics/Technics_NewProducts_8-1980.md
@@ -8,16 +8,6 @@ redirect_from:
   - "/docs/brochures/Technics/Technics_NewProducts_8-1980.html"
 ---
 
-<div id="adobe-dc-view" style="height: 80vh;">
-	<script src="https://acrobatservices.adobe.com/view-sdk/viewer.js"></script>
-	<script type="text/javascript">
-		document.addEventListener("adobe_dc_view_sdk.ready", function(){ 
-			var adobeDCView = new AdobeDC.View({clientId: "5aca0821dfc443928ce227808de9010e", divId: "adobe-dc-view"});
-			adobeDCView.previewFile({
-				content:{location: {url: "/assets/pdfs/Technics_NP8-1980.pdf"}},
-				metaData:{fileName: "Technics_NP8-1980.pdf"}
-			}, {defaultViewMode: "FIT_WIDTH", showAnnotationTools: false});
-		});
-	</script>
-	<br class="clear"/>
-</div>
+<div class="pdf-embed" data-pdf-url="{{ '/assets/pdfs/Technics_NP8-1980.pdf' | relative_url }}"></div>
+
+<script type="module" src="{{ '/assets/js/pdf-embed.js' | relative_url }}"></script>

--- a/brochures/Technics/Technics_NewProducts_9-1981.md
+++ b/brochures/Technics/Technics_NewProducts_9-1981.md
@@ -8,16 +8,6 @@ redirect_from:
   - "/docs/brochures/Technics/Technics_NewProducts_9-1981.html"
 ---
 
-<div id="adobe-dc-view" style="height: 80vh;">
-	<script src="https://acrobatservices.adobe.com/view-sdk/viewer.js"></script>
-	<script type="text/javascript">
-		document.addEventListener("adobe_dc_view_sdk.ready", function(){ 
-			var adobeDCView = new AdobeDC.View({clientId: "5aca0821dfc443928ce227808de9010e", divId: "adobe-dc-view"});
-			adobeDCView.previewFile({
-				content:{location: {url: "/assets/pdfs/Technics_NP9-1981.pdf"}},
-				metaData:{fileName: "Technics_NP9-1981.pdf"}
-			}, {defaultViewMode: "FIT_WIDTH", showAnnotationTools: false});
-		});
-	</script>
-	<br class="clear"/>
-</div>
+<div class="pdf-embed" data-pdf-url="{{ '/assets/pdfs/Technics_NP9-1981.pdf' | relative_url }}"></div>
+
+<script type="module" src="{{ '/assets/js/pdf-embed.js' | relative_url }}"></script>

--- a/brochures/Technics/Technics_PowerDocument81.md
+++ b/brochures/Technics/Technics_PowerDocument81.md
@@ -8,16 +8,6 @@ redirect_from:
   - "/docs/brochures/Technics/Technics_PowerDocument81.html"
 ---
 
-<div id="adobe-dc-view" style="height: 80vh;">
-	<script src="https://acrobatservices.adobe.com/view-sdk/viewer.js"></script>
-	<script type="text/javascript">
-		document.addEventListener("adobe_dc_view_sdk.ready", function(){ 
-			var adobeDCView = new AdobeDC.View({clientId: "5aca0821dfc443928ce227808de9010e", divId: "adobe-dc-view"});
-			adobeDCView.previewFile({
-				content:{location: {url: "/assets/pdfs/Technics_Power_Document_81.pdf"}},
-				metaData:{fileName: "Technics_Power_Document_81.pdf"}
-			}, {defaultViewMode: "FIT_WIDTH", showAnnotationTools: false});
-		});
-	</script>
-	<br class="clear"/>
-</div>
+<div class="pdf-embed" data-pdf-url="{{ '/assets/pdfs/Technics_Power_Document_81.pdf' | relative_url }}"></div>
+
+<script type="module" src="{{ '/assets/js/pdf-embed.js' | relative_url }}"></script>

--- a/brochures/Technics/Technics_ProSeries.md
+++ b/brochures/Technics/Technics_ProSeries.md
@@ -8,16 +8,6 @@ redirect_from:
   - "/docs/brochures/Technics/Technics_ProSeries.html"
 ---
 
-<div id="adobe-dc-view" style="height: 80vh;">
-	<script src="https://acrobatservices.adobe.com/view-sdk/viewer.js"></script>
-	<script type="text/javascript">
-		document.addEventListener("adobe_dc_view_sdk.ready", function(){ 
-			var adobeDCView = new AdobeDC.View({clientId: "5aca0821dfc443928ce227808de9010e", divId: "adobe-dc-view"});
-			adobeDCView.previewFile({
-				content:{location: {url: "/assets/pdfs/Technics_Pro_Series.pdf"}},
-				metaData:{fileName: "Technics_Pro_Series.pdf"}
-			}, {defaultViewMode: "FIT_WIDTH", showAnnotationTools: false});
-		});
-	</script>
-	<br class="clear"/>
-</div>
+<div class="pdf-embed" data-pdf-url="{{ '/assets/pdfs/Technics_Pro_Series.pdf' | relative_url }}"></div>
+
+<script type="module" src="{{ '/assets/js/pdf-embed.js' | relative_url }}"></script>

--- a/manuals/Technics/Technics_EPA-500_ArmUnits.md
+++ b/manuals/Technics/Technics_EPA-500_ArmUnits.md
@@ -8,16 +8,6 @@ redirect_from:
   - "/docs/manuals/Technics/Technics_EPA-500_ArmUnits.html"
 ---
 
-<div id="adobe-dc-view" style="height: 80vh;">
-	<script src="https://acrobatservices.adobe.com/view-sdk/viewer.js"></script>
-	<script type="text/javascript">
-		document.addEventListener("adobe_dc_view_sdk.ready", function(){ 
-			var adobeDCView = new AdobeDC.View({clientId: "5aca0821dfc443928ce227808de9010e", divId: "adobe-dc-view"});
-			adobeDCView.previewFile({
-				content:{location: {url: "/assets/pdfs/Technics_EPA-500-MatchingArmUnits.pdf"}},
-				metaData:{fileName: "Technics_EPA-500-MatchingArmUnits.pdf"}
-			}, {defaultViewMode: "FIT_WIDTH", showAnnotationTools: false});
-		});
-	</script>
-	<br class="clear"/>
-</div>
+<div class="pdf-embed" data-pdf-url="{{ '/assets/pdfs/Technics_EPA-500-MatchingArmUnits.pdf' | relative_url }}"></div>
+
+<script type="module" src="{{ '/assets/js/pdf-embed.js' | relative_url }}"></script>

--- a/manuals/Technics/Technics_TG_SP-20.md
+++ b/manuals/Technics/Technics_TG_SP-20.md
@@ -8,16 +8,6 @@ redirect_from:
   - "/docs/manuals/Technics/Technics_TG_SP-20.html"
 ---
 
-<div id="adobe-dc-view" style="height: 80vh;">
-	<script src="https://acrobatservices.adobe.com/view-sdk/viewer.js"></script>
-	<script type="text/javascript">
-		document.addEventListener("adobe_dc_view_sdk.ready", function(){ 
-			var adobeDCView = new AdobeDC.View({clientId: "5aca0821dfc443928ce227808de9010e", divId: "adobe-dc-view"});
-			adobeDCView.previewFile({
-				content:{location: {url: "/assets/pdfs/Technics_TG_SP-20.pdf"}},
-				metaData:{fileName: "Technics_TG_SP-20.pdf"}
-			}, {defaultViewMode: "FIT_WIDTH", showAnnotationTools: false});
-		});
-	</script>
-	<br class="clear"/>
-</div>
+<div class="pdf-embed" data-pdf-url="{{ '/assets/pdfs/Technics_TG_SP-20.pdf' | relative_url }}"></div>
+
+<script type="module" src="{{ '/assets/js/pdf-embed.js' | relative_url }}"></script>

--- a/manuals/Technics/Technics_UM_EPA-100.md
+++ b/manuals/Technics/Technics_UM_EPA-100.md
@@ -8,16 +8,6 @@ redirect_from:
   - "/docs/manuals/Technics/Technics_UM_EPA-100.html"
 ---
 
-<div id="adobe-dc-view" style="height: 80vh;">
-	<script src="https://acrobatservices.adobe.com/view-sdk/viewer.js"></script>
-	<script type="text/javascript">
-		document.addEventListener("adobe_dc_view_sdk.ready", function(){ 
-			var adobeDCView = new AdobeDC.View({clientId: "5aca0821dfc443928ce227808de9010e", divId: "adobe-dc-view"});
-			adobeDCView.previewFile({
-				content:{location: {url: "/assets/pdfs/Technics_UM_EPA-100.pdf"}},
-				metaData:{fileName: "Technics_UM_EPA-100.pdf"}
-			}, {defaultViewMode: "FIT_WIDTH", showAnnotationTools: false});
-		});
-	</script>
-	<br class="clear"/>
-</div>
+<div class="pdf-embed" data-pdf-url="{{ '/assets/pdfs/Technics_UM_EPA-100.pdf' | relative_url }}"></div>
+
+<script type="module" src="{{ '/assets/js/pdf-embed.js' | relative_url }}"></script>

--- a/manuals/Technics/Technics_UM_EPC-450C-II.md
+++ b/manuals/Technics/Technics_UM_EPC-450C-II.md
@@ -8,16 +8,6 @@ redirect_from:
   - "/docs/manuals/Technics/Technics_UM_EPC-450C-II.html"
 ---
 
-<div id="adobe-dc-view" style="height: 80vh;">
-	<script src="https://acrobatservices.adobe.com/view-sdk/viewer.js"></script>
-	<script type="text/javascript">
-		document.addEventListener("adobe_dc_view_sdk.ready", function(){ 
-			var adobeDCView = new AdobeDC.View({clientId: "5aca0821dfc443928ce227808de9010e", divId: "adobe-dc-view"});
-			adobeDCView.previewFile({
-				content:{location: {url: "/assets/pdfs/Technics_UM_EPC-450C-II.pdf"}},
-				metaData:{fileName: "Technics_UM_EPC-450C-II.pdf"}
-			}, {defaultViewMode: "FIT_WIDTH", showAnnotationTools: false});
-		});
-	</script>
-	<br class="clear"/>
-</div>
+<div class="pdf-embed" data-pdf-url="{{ '/assets/pdfs/Technics_UM_EPC-450C-II.pdf' | relative_url }}"></div>
+
+<script type="module" src="{{ '/assets/js/pdf-embed.js' | relative_url }}"></script>

--- a/manuals/Technics/Technics_UM_SH-10B5.md
+++ b/manuals/Technics/Technics_UM_SH-10B5.md
@@ -8,16 +8,6 @@ redirect_from:
   - "/docs/manuals/Technics/Technics_UM_SH-10B5.html"
 ---
 
-<div id="adobe-dc-view" style="height: 80vh;">
-	<script src="https://acrobatservices.adobe.com/view-sdk/viewer.js"></script>
-	<script type="text/javascript">
-		document.addEventListener("adobe_dc_view_sdk.ready", function(){ 
-			var adobeDCView = new AdobeDC.View({clientId: "5aca0821dfc443928ce227808de9010e", divId: "adobe-dc-view"});
-			adobeDCView.previewFile({
-				content:{location: {url: "/assets/pdfs/Techncis_UM_SH-10B5.pdf"}},
-				metaData:{fileName: "Techncis_UM_SH-10B5.pdf"}
-			}, {defaultViewMode: "FIT_WIDTH", showAnnotationTools: false});
-		});
-	</script>
-	<br class="clear"/>
-</div>
+<div class="pdf-embed" data-pdf-url="{{ '/assets/pdfs/Techncis_UM_SH-10B5.pdf' | relative_url }}"></div>
+
+<script type="module" src="{{ '/assets/js/pdf-embed.js' | relative_url }}"></script>

--- a/manuals/Technics/Technics_UM_SP-10MK3.md
+++ b/manuals/Technics/Technics_UM_SP-10MK3.md
@@ -8,16 +8,6 @@ redirect_from:
   - "/docs/manuals/Technics/Technics_UM_SP-10MK3.html"
 ---
 
-<div id="adobe-dc-view" style="height: 80vh;">
-	<script src="https://acrobatservices.adobe.com/view-sdk/viewer.js"></script>
-	<script type="text/javascript">
-		document.addEventListener("adobe_dc_view_sdk.ready", function(){ 
-			var adobeDCView = new AdobeDC.View({clientId: "5aca0821dfc443928ce227808de9010e", divId: "adobe-dc-view"});
-			adobeDCView.previewFile({
-				content:{location: {url: "/assets/pdfs/Technics_UM_SP-10MK3.pdf"}},
-				metaData:{fileName: "Technics_UM_SP-10MK3.pdf"}
-			}, {defaultViewMode: "FIT_WIDTH", showAnnotationTools: false});
-		});
-	</script>
-	<br class="clear"/>
-</div>
+<div class="pdf-embed" data-pdf-url="{{ '/assets/pdfs/Technics_UM_SP-10MK3.pdf' | relative_url }}"></div>
+
+<script type="module" src="{{ '/assets/js/pdf-embed.js' | relative_url }}"></script>


### PR DESCRIPTION
## Summary
- Converts all 15 remaining pages (9 brochures, 6 manuals) from Adobe Acrobat SDK to pdf-embed.js
- No Adobe dependencies remain on the site

## Test plan
- [ ] Spot check a few brochure and manual pages render correctly
- [ ] Download links work

🤖 Generated with [Claude Code](https://claude.com/claude-code)