### PR TITLE
Fix PDF page size distortion on mixed-size documents

### DIFF
--- a/_layouts/pdf.html
+++ b/_layouts/pdf.html
@@ -1,47 +1,9 @@
 ---
-layout: table_wrappers
+layout: default
 ---
 
-<!DOCTYPE html>
+{{ content }}
 
-<html lang="{{ site.lang | default: 'en-US' }}">
-{% include head.html %}
-<body>
-  <a class="skip-to-main" href="#main-content">Skip to main content</a>
-  {% include icons/icons.html %}
-  {% if page.nav_enabled == true %}
-    {% include components/sidebar.html %}
-  {% elsif layout.nav_enabled == true and page.nav_enabled == nil %}
-    {% include components/sidebar.html %}
-  {% elsif site.nav_enabled != false and layout.nav_enabled == nil and page.nav_enabled == nil %}
-    {% include components/sidebar.html %}
-  {% endif %}
-  <div class="main" id="top">
-    {% include components/header.html %}
-    <div class="main-content-wrap">
-      {% include components/breadcrumbs.html %}
-      <div id="main-content" class="main-content">
-        <main>
-          {% if site.heading_anchors != false %}
-            {% include vendor/anchor_headings.html html=content beforeHeading="true" anchorBody="<svg viewBox=\"0 0 16 16\" aria-hidden=\"true\"><use xlink:href=\"#svg-link\"></use></svg>" anchorClass="anchor-heading" anchorAttrs="aria-labelledby=\"%html_id%\"" %}
-          {% else %}
-            {{ content }}
-          {% endif %}
+<div class="pdf-embed" data-pdf-url="{{ page.pdf | relative_url }}"{% if page.pdf_mixed_sizes %} data-pdf-mixed-sizes="true"{% endif %}></div>
 
-          {% if page.has_toc != false %}
-            {% include components/children_nav.html %}
-          {% endif %}
-        </main>
-        {% include components/footer.html %}
-      </div>
-    </div>
-    {% if site.search_enabled != false %}
-      {% include components/search_footer.html %}
-    {% endif %}
-  </div>
-
-  {% if site.mermaid %}
-    {% include components/mermaid.html %}
-  {% endif %}
-</body>
-</html>
+<script type="module" src="{{ '/assets/js/pdf-embed.js' | relative_url }}"></script>

--- a/assets/js/pdf-embed.js
+++ b/assets/js/pdf-embed.js
@@ -41,16 +41,32 @@ function embedPDF(container) {
       targetPage = Math.min(Math.max(parseInt(hashMatch[1], 10), 1), pdf.numPages);
     }
 
-    // Measure every page individually for correct placeholder sizes
-    var pagePromises = [];
-    for (var i = 1; i <= pdf.numPages; i++) {
-      pagePromises.push(pdf.getPage(i));
+    var mixedSizes = container.hasAttribute("data-pdf-mixed-sizes");
+
+    // Measure pages for placeholder sizes
+    var measurePromise;
+    if (mixedSizes) {
+      // Measure every page individually
+      var pagePromises = [];
+      for (var i = 1; i <= pdf.numPages; i++) {
+        pagePromises.push(pdf.getPage(i));
+      }
+      measurePromise = Promise.all(pagePromises);
+    } else {
+      // Use first page dimensions for all placeholders
+      measurePromise = pdf.getPage(1).then(function (firstPage) {
+        var arr = [];
+        for (var i = 0; i < pdf.numPages; i++) {
+          arr.push(firstPage);
+        }
+        return arr;
+      });
     }
 
-    Promise.all(pagePromises).then(function (pages) {
+    measurePromise.then(function (pages) {
       var containerWidth = container.clientWidth;
 
-      // Create correctly-sized placeholders for each page
+      // Create placeholders
       for (var i = 0; i < pages.length; i++) {
         var unscaledViewport = pages[i].getViewport({ scale: 1 });
         var scale = containerWidth / unscaledViewport.width;

--- a/assets/js/pdf-embed.js
+++ b/assets/js/pdf-embed.js
@@ -11,7 +11,6 @@ function renderPageToCanvas(pdf, pageNum, container) {
     var renderScale = scale * (window.devicePixelRatio || 1);
     var viewport = page.getViewport({ scale: renderScale });
 
-    // Find the placeholder and replace it
     var placeholder = document.getElementById("pdf-page-" + pageNum);
     placeholder.width = viewport.width;
     placeholder.height = viewport.height;
@@ -42,17 +41,23 @@ function embedPDF(container) {
       targetPage = Math.min(Math.max(parseInt(hashMatch[1], 10), 1), pdf.numPages);
     }
 
-    // Get first page to determine aspect ratio for placeholders
-    pdf.getPage(1).then(function (firstPage) {
-      var unscaledViewport = firstPage.getViewport({ scale: 1 });
-      var containerWidth = container.clientWidth;
-      var scale = containerWidth / unscaledViewport.width;
-      var cssHeight = Math.ceil(unscaledViewport.height * scale);
+    // Measure every page individually for correct placeholder sizes
+    var pagePromises = [];
+    for (var i = 1; i <= pdf.numPages; i++) {
+      pagePromises.push(pdf.getPage(i));
+    }
 
-      // Create all canvas placeholders up front with correct dimensions
-      for (var i = 1; i <= pdf.numPages; i++) {
+    Promise.all(pagePromises).then(function (pages) {
+      var containerWidth = container.clientWidth;
+
+      // Create correctly-sized placeholders for each page
+      for (var i = 0; i < pages.length; i++) {
+        var unscaledViewport = pages[i].getViewport({ scale: 1 });
+        var scale = containerWidth / unscaledViewport.width;
+        var cssHeight = Math.ceil(unscaledViewport.height * scale);
+
         var canvas = document.createElement("canvas");
-        canvas.id = "pdf-page-" + i;
+        canvas.id = "pdf-page-" + (i + 1);
         canvas.style.cssText = "width:100%;height:" + cssHeight + "px;display:block;margin-bottom:2px;background:#f5f5f5;";
         container.appendChild(canvas);
       }
@@ -69,12 +74,9 @@ function embedPDF(container) {
       if (targetPage) {
         renderPageToCanvas(pdf, targetPage, container).then(function (canvas) {
           canvas.scrollIntoView({ behavior: "instant" });
-
-          // Render remaining pages in order
           renderRemaining(pdf, container, targetPage);
         });
       } else {
-        // No target — render sequentially from page 1
         renderSequential(pdf, container, 1);
       }
     });
@@ -95,7 +97,6 @@ function renderSequential(pdf, container, pageNum) {
 }
 
 function renderRemaining(pdf, container, skip) {
-  // Render all pages except the one already rendered, in order
   var pages = [];
   for (var i = 1; i <= pdf.numPages; i++) {
     if (i !== skip) pages.push(i);

--- a/brochures/Technics/Technics_EPA-500_System.md
+++ b/brochures/Technics/Technics_EPA-500_System.md
@@ -1,13 +1,10 @@
 ---
-layout: default
+layout: pdf
 title: Technics EPA-500 System
 parent: Technics
 ancestor: Brochures
 nav_order: 9
 redirect_from:
   - "/docs/brochures/Technics/Technics_EPA-500_System.html"
+pdf: /assets/pdfs/Technics_EPA-500_System.pdf
 ---
-
-<div class="pdf-embed" data-pdf-url="{{ '/assets/pdfs/Technics_EPA-500_System.pdf' | relative_url }}"></div>
-
-<script type="module" src="{{ '/assets/js/pdf-embed.js' | relative_url }}"></script>

--- a/brochures/Technics/Technics_NewProducts_10-1980.md
+++ b/brochures/Technics/Technics_NewProducts_10-1980.md
@@ -1,13 +1,10 @@
 ---
-layout: default
+layout: pdf
 title: New Products 10-1980 (EPC-100CMK3)
 parent: Technics
 ancestor: Brochures
 nav_order: 3
 redirect_from:
   - "/docs/brochures/Technics/Technics_NewProducts_10-1980.html"
+pdf: /assets/pdfs/Technics_NP10-1980.pdf
 ---
-
-<div class="pdf-embed" data-pdf-url="{{ '/assets/pdfs/Technics_NP10-1980.pdf' | relative_url }}"></div>
-
-<script type="module" src="{{ '/assets/js/pdf-embed.js' | relative_url }}"></script>

--- a/brochures/Technics/Technics_NewProducts_10-1982-1.md
+++ b/brochures/Technics/Technics_NewProducts_10-1982-1.md
@@ -1,13 +1,10 @@
 ---
-layout: default
+layout: pdf
 title: New Products 10-1982 (EPC-100CMK4)
 parent: Technics
 ancestor: Brochures
 nav_order: 5
 redirect_from:
   - "/docs/brochures/Technics/Technics_NewProducts_10-1982-1.html"
+pdf: /assets/pdfs/Technics_NP10-1982_1.pdf
 ---
-
-<div class="pdf-embed" data-pdf-url="{{ '/assets/pdfs/Technics_NP10-1982_1.pdf' | relative_url }}"></div>
-
-<script type="module" src="{{ '/assets/js/pdf-embed.js' | relative_url }}"></script>

--- a/brochures/Technics/Technics_NewProducts_10-1982-2.md
+++ b/brochures/Technics/Technics_NewProducts_10-1982-2.md
@@ -1,13 +1,10 @@
 ---
-layout: default
+layout: pdf
 title: New Products 10-1982 (SL-1000MK3D)
 parent: Technics
 ancestor: Brochures
 nav_order: 6
 redirect_from:
   - "/docs/brochures/Technics/Technics_NewProducts_10-1982-2.html"
+pdf: /assets/pdfs/Technics_NP10-1982_2.pdf
 ---
-
-<div class="pdf-embed" data-pdf-url="{{ '/assets/pdfs/Technics_NP10-1982_2.pdf' | relative_url }}"></div>
-
-<script type="module" src="{{ '/assets/js/pdf-embed.js' | relative_url }}"></script>

--- a/brochures/Technics/Technics_NewProducts_4-1979.md
+++ b/brochures/Technics/Technics_NewProducts_4-1979.md
@@ -1,13 +1,10 @@
 ---
-layout: default
+layout: pdf
 title: New Products 4-1979 (EPC-205CMK3)
 parent: Technics
 ancestor: Brochures
 nav_order: 1
 redirect_from:
   - "/docs/brochures/Technics/Technics_NewProducts_4-1979.html"
+pdf: /assets/pdfs/Technics_NP4-1979.pdf
 ---
-
-<div class="pdf-embed" data-pdf-url="{{ '/assets/pdfs/Technics_NP4-1979.pdf' | relative_url }}"></div>
-
-<script type="module" src="{{ '/assets/js/pdf-embed.js' | relative_url }}"></script>

--- a/brochures/Technics/Technics_NewProducts_8-1980.md
+++ b/brochures/Technics/Technics_NewProducts_8-1980.md
@@ -1,13 +1,10 @@
 ---
-layout: default
+layout: pdf
 title: New Products 8-1980 (EPA-A505)
 parent: Technics
 ancestor: Brochures
 nav_order: 2
 redirect_from:
   - "/docs/brochures/Technics/Technics_NewProducts_8-1980.html"
+pdf: /assets/pdfs/Technics_NP8-1980.pdf
 ---
-
-<div class="pdf-embed" data-pdf-url="{{ '/assets/pdfs/Technics_NP8-1980.pdf' | relative_url }}"></div>
-
-<script type="module" src="{{ '/assets/js/pdf-embed.js' | relative_url }}"></script>

--- a/brochures/Technics/Technics_NewProducts_9-1981.md
+++ b/brochures/Technics/Technics_NewProducts_9-1981.md
@@ -1,13 +1,10 @@
 ---
-layout: default
+layout: pdf
 title: New Products 9-1981 (EPC-305MCMK2)
 parent: Technics
 ancestor: Brochures
 nav_order: 4
 redirect_from:
   - "/docs/brochures/Technics/Technics_NewProducts_9-1981.html"
+pdf: /assets/pdfs/Technics_NP9-1981.pdf
 ---
-
-<div class="pdf-embed" data-pdf-url="{{ '/assets/pdfs/Technics_NP9-1981.pdf' | relative_url }}"></div>
-
-<script type="module" src="{{ '/assets/js/pdf-embed.js' | relative_url }}"></script>

--- a/brochures/Technics/Technics_PowerDocument81.md
+++ b/brochures/Technics/Technics_PowerDocument81.md
@@ -1,13 +1,10 @@
 ---
-layout: default
+layout: pdf
 title: Technics Power Document '81
 parent: Technics
 ancestor: Brochures
 nav_order: 7
 redirect_from:
   - "/docs/brochures/Technics/Technics_PowerDocument81.html"
+pdf: /assets/pdfs/Technics_Power_Document_81.pdf
 ---
-
-<div class="pdf-embed" data-pdf-url="{{ '/assets/pdfs/Technics_Power_Document_81.pdf' | relative_url }}"></div>
-
-<script type="module" src="{{ '/assets/js/pdf-embed.js' | relative_url }}"></script>

--- a/brochures/Technics/Technics_ProSeries.md
+++ b/brochures/Technics/Technics_ProSeries.md
@@ -1,13 +1,10 @@
 ---
-layout: default
+layout: pdf
 title: Technics Pro Series
 parent: Technics
 ancestor: Brochures
 nav_order: 8
 redirect_from:
   - "/docs/brochures/Technics/Technics_ProSeries.html"
+pdf: /assets/pdfs/Technics_Pro_Series.pdf
 ---
-
-<div class="pdf-embed" data-pdf-url="{{ '/assets/pdfs/Technics_Pro_Series.pdf' | relative_url }}"></div>
-
-<script type="module" src="{{ '/assets/js/pdf-embed.js' | relative_url }}"></script>

--- a/manuals/Technics/Technics_EPA-500_ArmUnits.md
+++ b/manuals/Technics/Technics_EPA-500_ArmUnits.md
@@ -1,13 +1,10 @@
 ---
-layout: default
+layout: pdf
 title: EPA-500 Matching Arm Units
 parent: Technics
 ancestor: Manuals
 nav_order: 1
 redirect_from:
   - "/docs/manuals/Technics/Technics_EPA-500_ArmUnits.html"
+pdf: /assets/pdfs/Technics_EPA-500-MatchingArmUnits.pdf
 ---
-
-<div class="pdf-embed" data-pdf-url="{{ '/assets/pdfs/Technics_EPA-500-MatchingArmUnits.pdf' | relative_url }}"></div>
-
-<script type="module" src="{{ '/assets/js/pdf-embed.js' | relative_url }}"></script>

--- a/manuals/Technics/Technics_TG_SP-20.md
+++ b/manuals/Technics/Technics_TG_SP-20.md
@@ -1,13 +1,10 @@
 ---
-layout: default
+layout: pdf
 title: SP-20 Technical Guide
 parent: Technics
 ancestor: Manuals
 nav_order: 1
 redirect_from:
   - "/docs/manuals/Technics/Technics_TG_SP-20.html"
+pdf: /assets/pdfs/Technics_TG_SP-20.pdf
 ---
-
-<div class="pdf-embed" data-pdf-url="{{ '/assets/pdfs/Technics_TG_SP-20.pdf' | relative_url }}"></div>
-
-<script type="module" src="{{ '/assets/js/pdf-embed.js' | relative_url }}"></script>

--- a/manuals/Technics/Technics_UM_EPA-100.md
+++ b/manuals/Technics/Technics_UM_EPA-100.md
@@ -1,13 +1,11 @@
 ---
-layout: default
+layout: pdf
 title: EPA-100 User Manual
 parent: Technics
 ancestor: Manuals
 nav_order: 1
 redirect_from:
   - "/docs/manuals/Technics/Technics_UM_EPA-100.html"
+pdf: /assets/pdfs/Technics_UM_EPA-100.pdf
+pdf_mixed_sizes: true
 ---
-
-<div class="pdf-embed" data-pdf-url="{{ '/assets/pdfs/Technics_UM_EPA-100.pdf' | relative_url }}"></div>
-
-<script type="module" src="{{ '/assets/js/pdf-embed.js' | relative_url }}"></script>

--- a/manuals/Technics/Technics_UM_EPC-450C-II.md
+++ b/manuals/Technics/Technics_UM_EPC-450C-II.md
@@ -1,13 +1,10 @@
 ---
-layout: default
+layout: pdf
 title: EPC-450C-II User Manual
 parent: Technics
 ancestor: Manuals
 nav_order: 1
 redirect_from:
   - "/docs/manuals/Technics/Technics_UM_EPC-450C-II.html"
+pdf: /assets/pdfs/Technics_UM_EPC-450C-II.pdf
 ---
-
-<div class="pdf-embed" data-pdf-url="{{ '/assets/pdfs/Technics_UM_EPC-450C-II.pdf' | relative_url }}"></div>
-
-<script type="module" src="{{ '/assets/js/pdf-embed.js' | relative_url }}"></script>

--- a/manuals/Technics/Technics_UM_SH-10B5.md
+++ b/manuals/Technics/Technics_UM_SH-10B5.md
@@ -1,13 +1,10 @@
 ---
-layout: default
+layout: pdf
 title: SH-10B5 User Manual
 parent: Technics
 ancestor: Manuals
 nav_order: 1
 redirect_from:
   - "/docs/manuals/Technics/Technics_UM_SH-10B5.html"
+pdf: /assets/pdfs/Techncis_UM_SH-10B5.pdf
 ---
-
-<div class="pdf-embed" data-pdf-url="{{ '/assets/pdfs/Techncis_UM_SH-10B5.pdf' | relative_url }}"></div>
-
-<script type="module" src="{{ '/assets/js/pdf-embed.js' | relative_url }}"></script>

--- a/manuals/Technics/Technics_UM_SP-10MK3.md
+++ b/manuals/Technics/Technics_UM_SP-10MK3.md
@@ -1,13 +1,10 @@
 ---
-layout: default
+layout: pdf
 title: SP-10MK3 User Manual
 parent: Technics
 ancestor: Manuals
 nav_order: 1
 redirect_from:
   - "/docs/manuals/Technics/Technics_UM_SP-10MK3.html"
+pdf: /assets/pdfs/Technics_UM_SP-10MK3.pdf
 ---
-
-<div class="pdf-embed" data-pdf-url="{{ '/assets/pdfs/Technics_UM_SP-10MK3.pdf' | relative_url }}"></div>
-
-<script type="module" src="{{ '/assets/js/pdf-embed.js' | relative_url }}"></script>

--- a/test-records/CBS/CTC.md
+++ b/test-records/CBS/CTC.md
@@ -1,12 +1,9 @@
 ---
-layout: default
+layout: pdf
 title: CBS Technology Center
 parent: Test Records
 nav_order: 2
 redirect_from:
   - "/docs/test-records/CBS/CTC.html"
+pdf: /assets/pdfs/CBS Pro Series Test Records.pdf
 ---
-
-<div class="pdf-embed" data-pdf-url="{{ '/assets/pdfs/CBS Pro Series Test Records.pdf' | relative_url }}"></div>
-
-<script type="module" src="{{ '/assets/js/pdf-embed.js' | relative_url }}"></script>


### PR DESCRIPTION
## Summary
- Measures each page individually instead of assuming all pages match page 1
- Fixes distortion on documents with mixed page sizes (e.g. EPA-100 manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)