### PR TITLE
Enable mixed page sizes for SP-20 Technical Guide

### DIFF
--- a/manuals/Technics/Technics_TG_SP-20.md
+++ b/manuals/Technics/Technics_TG_SP-20.md
@@ -7,4 +7,5 @@ nav_order: 1
 redirect_from:
   - "/docs/manuals/Technics/Technics_TG_SP-20.html"
 pdf: /assets/pdfs/Technics_TG_SP-20.pdf
+pdf_mixed_sizes: true
 ---


### PR DESCRIPTION
## Summary
- Adds `pdf_mixed_sizes: true` to SP-20 Technical Guide

🤖 Generated with [Claude Code](https://claude.com/claude-code)