### PR TITLE
Fix PDF embed responsive sizing

### DIFF
--- a/assets/js/pdf-embed.js
+++ b/assets/js/pdf-embed.js
@@ -64,17 +64,13 @@ function embedPDF(container) {
     }
 
     measurePromise.then(function (pages) {
-      var containerWidth = container.clientWidth;
-
-      // Create placeholders
+      // Create placeholders with aspect-ratio for responsive sizing
       for (var i = 0; i < pages.length; i++) {
         var unscaledViewport = pages[i].getViewport({ scale: 1 });
-        var scale = containerWidth / unscaledViewport.width;
-        var cssHeight = Math.ceil(unscaledViewport.height * scale);
 
         var canvas = document.createElement("canvas");
         canvas.id = "pdf-page-" + (i + 1);
-        canvas.style.cssText = "width:100%;height:" + cssHeight + "px;display:block;margin-bottom:2px;background:#f5f5f5;";
+        canvas.style.cssText = "width:100%;height:auto;display:block;margin-bottom:2px;background:#f5f5f5;aspect-ratio:" + unscaledViewport.width + "/" + unscaledViewport.height + ";";
         container.appendChild(canvas);
       }
 


### PR DESCRIPTION
## Summary
- Uses CSS `aspect-ratio` instead of fixed pixel heights on canvas placeholders
- Width stays at 100%, height scales automatically when container resizes
- No more squished pages when narrowing the window

🤖 Generated with [Claude Code](https://claude.com/claude-code)