### PR TITLE
Dark placeholder background for PDF embeds

### DIFF
--- a/assets/js/pdf-embed.js
+++ b/assets/js/pdf-embed.js
@@ -70,7 +70,7 @@ function embedPDF(container) {
 
         var canvas = document.createElement("canvas");
         canvas.id = "pdf-page-" + (i + 1);
-        canvas.style.cssText = "width:100%;height:auto;display:block;margin-bottom:2px;background:#f5f5f5;aspect-ratio:" + unscaledViewport.width + "/" + unscaledViewport.height + ";";
+        canvas.style.cssText = "width:100%;height:auto;display:block;margin-bottom:2px;background:#1a1a1a;aspect-ratio:" + unscaledViewport.width + "/" + unscaledViewport.height + ";";
         container.appendChild(canvas);
       }
 


### PR DESCRIPTION
## Summary
- Changes PDF placeholder background from light gray (#f5f5f5) to dark (#1a1a1a) to match site theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)