### PR TITLE
Add lightbox image viewer for imagery pages

### DIFF
--- a/_layouts/imagery.html
+++ b/_layouts/imagery.html
@@ -1,0 +1,9 @@
+---
+layout: default
+---
+
+<link rel="stylesheet" href="{{ '/assets/css/lightbox.css' | relative_url }}">
+
+{{ content }}
+
+<script src="{{ '/assets/js/lightbox.js' | relative_url }}"></script>

--- a/assets/css/lightbox.css
+++ b/assets/css/lightbox.css
@@ -1,0 +1,30 @@
+.lightbox-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.92);
+  z-index: 10000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+.lightbox-img {
+  max-width: 92vw;
+  max-height: 92vh;
+  object-fit: contain;
+  cursor: default;
+}
+
+.lightbox-counter {
+  position: absolute;
+  bottom: 16px;
+  left: 50%;
+  transform: translateX(-50%);
+  color: rgba(255, 255, 255, 0.5);
+  font-size: 13px;
+  font-family: -apple-system, BlinkMacSystemFont, sans-serif;
+}

--- a/assets/js/lightbox.js
+++ b/assets/js/lightbox.js
@@ -1,0 +1,67 @@
+"use strict";
+(function () {
+  // Collect all images in main content
+  var images = Array.from(document.querySelectorAll(".main-content img"));
+  if (!images.length) return;
+
+  // Create overlay
+  var overlay = document.createElement("div");
+  overlay.className = "lightbox-overlay";
+  overlay.style.display = "none";
+
+  var img = document.createElement("img");
+  img.className = "lightbox-img";
+  overlay.appendChild(img);
+
+  var counter = document.createElement("div");
+  counter.className = "lightbox-counter";
+  overlay.appendChild(counter);
+
+  document.body.appendChild(overlay);
+
+  var currentIndex = -1;
+
+  function show(index) {
+    if (index < 0 || index >= images.length) return;
+    currentIndex = index;
+    img.src = images[index].src;
+    img.alt = images[index].alt || "";
+    counter.textContent = (index + 1) + " / " + images.length;
+    counter.style.display = images.length > 1 ? "block" : "none";
+    overlay.style.display = "flex";
+    document.body.style.overflow = "hidden";
+  }
+
+  function hide() {
+    overlay.style.display = "none";
+    document.body.style.overflow = "";
+    currentIndex = -1;
+  }
+
+  function next() {
+    if (currentIndex < images.length - 1) show(currentIndex + 1);
+  }
+
+  function prev() {
+    if (currentIndex > 0) show(currentIndex - 1);
+  }
+
+  // Click image to open
+  images.forEach(function (image, i) {
+    image.style.cursor = "pointer";
+    image.addEventListener("click", function () { show(i); });
+  });
+
+  // Click overlay to close (but not on the image itself)
+  overlay.addEventListener("click", function (e) {
+    if (e.target === overlay) hide();
+  });
+
+  // Keyboard navigation
+  document.addEventListener("keydown", function (e) {
+    if (currentIndex === -1) return;
+    if (e.key === "Escape") hide();
+    else if (e.key === "ArrowRight") next();
+    else if (e.key === "ArrowLeft") prev();
+  });
+})();

--- a/imagery/Sony/XL88D.md
+++ b/imagery/Sony/XL88D.md
@@ -1,4 +1,5 @@
 ---
+layout: imagery
 title: XL-88D
 parent: Sony
 grand_parent: Imagery

--- a/imagery/Technics/100CMK3.md
+++ b/imagery/Technics/100CMK3.md
@@ -1,4 +1,5 @@
 ---
+layout: imagery
 title: EPC-100CMK3
 parent: Technics
 grand_parent: Imagery

--- a/imagery/Technics/EPA100.md
+++ b/imagery/Technics/EPA100.md
@@ -1,4 +1,5 @@
 ---
+layout: imagery
 title: EPA-100
 parent: Technics
 grand_parent: Imagery

--- a/imagery/Technics/SL1000MK3D.md
+++ b/imagery/Technics/SL1000MK3D.md
@@ -1,4 +1,5 @@
 ---
+layout: imagery
 title: SL-1000MK3D
 parent: Technics
 grand_parent: Imagery

--- a/imagery/Technics/SP-10MK3.md
+++ b/imagery/Technics/SP-10MK3.md
@@ -1,4 +1,5 @@
 ---
+layout: imagery
 title: SP-10MK3 / SL-1000MK3
 parent: Technics
 grand_parent: Imagery

--- a/imagery/Technics/SP-10MKII.md
+++ b/imagery/Technics/SP-10MKII.md
@@ -1,4 +1,5 @@
 ---
+layout: imagery
 title: SP-10MKII / SL-1000MKII
 parent: Technics
 grand_parent: Imagery

--- a/imagery/Victor/MCL1000.md
+++ b/imagery/Victor/MCL1000.md
@@ -1,4 +1,5 @@
 ---
+layout: imagery
 title: MC-L1000
 parent: Victor
 grand_parent: Imagery


### PR DESCRIPTION
## Summary
- New lightbox overlay: click any image to view full-screen on a dark background
- Escape or click outside to close, arrow keys to navigate between images
- New `_layouts/imagery.html` layout includes lightbox CSS/JS automatically
- All 7 imagery pages updated to use the imagery layout

## Test plan
- [ ] Click image opens lightbox overlay
- [ ] Escape and click-outside close it
- [ ] Arrow keys navigate on multi-image pages (EPA-100)
- [ ] Counter shows "1 / 12" etc on multi-image pages
- [ ] Single-image pages hide the counter

🤖 Generated with [Claude Code](https://claude.com/claude-code)