### PR TITLE
Add touch, swipe and mouse navigation to lightbox

### DIFF
--- a/assets/css/lightbox.css
+++ b/assets/css/lightbox.css
@@ -17,6 +17,8 @@
   max-height: 92vh;
   object-fit: contain;
   cursor: default;
+  user-select: none;
+  -webkit-user-select: none;
 }
 
 .lightbox-counter {
@@ -27,4 +29,52 @@
   color: rgba(255, 255, 255, 0.5);
   font-size: 13px;
   font-family: -apple-system, BlinkMacSystemFont, sans-serif;
+}
+
+.lightbox-close {
+  position: absolute;
+  top: 12px;
+  right: 16px;
+  color: rgba(255, 255, 255, 0.6);
+  font-size: 32px;
+  cursor: pointer;
+  line-height: 1;
+  padding: 4px 8px;
+}
+
+.lightbox-close:hover {
+  color: #fff;
+}
+
+.lightbox-nav {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  color: rgba(255, 255, 255, 0.5);
+  font-size: 48px;
+  cursor: pointer;
+  padding: 16px;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+.lightbox-nav:hover {
+  color: #fff;
+}
+
+.lightbox-prev {
+  left: 8px;
+}
+
+.lightbox-next {
+  right: 8px;
+}
+
+@media (hover: none) and (pointer: coarse) {
+  .lightbox-nav {
+    display: none !important;
+  }
 }

--- a/assets/js/lightbox.js
+++ b/assets/js/lightbox.js
@@ -17,6 +17,23 @@
   counter.className = "lightbox-counter";
   overlay.appendChild(counter);
 
+  // Close button
+  var closeBtn = document.createElement("div");
+  closeBtn.className = "lightbox-close";
+  closeBtn.textContent = "\u00d7";
+  overlay.appendChild(closeBtn);
+
+  // Nav arrows (visible on non-touch devices, hidden on touch)
+  var prevBtn = document.createElement("div");
+  prevBtn.className = "lightbox-nav lightbox-prev";
+  prevBtn.textContent = "\u2039";
+  overlay.appendChild(prevBtn);
+
+  var nextBtn = document.createElement("div");
+  nextBtn.className = "lightbox-nav lightbox-next";
+  nextBtn.textContent = "\u203a";
+  overlay.appendChild(nextBtn);
+
   document.body.appendChild(overlay);
 
   var currentIndex = -1;
@@ -28,6 +45,8 @@
     img.alt = images[index].alt || "";
     counter.textContent = (index + 1) + " / " + images.length;
     counter.style.display = images.length > 1 ? "block" : "none";
+    prevBtn.style.display = images.length > 1 && index > 0 ? "flex" : "none";
+    nextBtn.style.display = images.length > 1 && index < images.length - 1 ? "flex" : "none";
     overlay.style.display = "flex";
     document.body.style.overflow = "hidden";
   }
@@ -52,10 +71,47 @@
     image.addEventListener("click", function () { show(i); });
   });
 
-  // Click overlay to close (but not on the image itself)
+  // Close button
+  closeBtn.addEventListener("click", hide);
+
+  // Click overlay background to close
   overlay.addEventListener("click", function (e) {
     if (e.target === overlay) hide();
   });
+
+  // Nav arrows
+  prevBtn.addEventListener("click", function (e) { e.stopPropagation(); prev(); });
+  nextBtn.addEventListener("click", function (e) { e.stopPropagation(); next(); });
+
+  // Tap left/right half of image to navigate on touch
+  img.addEventListener("click", function (e) {
+    if (images.length <= 1) return;
+    var rect = img.getBoundingClientRect();
+    var x = e.clientX - rect.left;
+    if (x < rect.width / 3) prev();
+    else if (x > rect.width * 2 / 3) next();
+    else hide();
+  });
+
+  // Swipe gestures
+  var touchStartX = 0;
+  var touchStartY = 0;
+
+  overlay.addEventListener("touchstart", function (e) {
+    touchStartX = e.touches[0].clientX;
+    touchStartY = e.touches[0].clientY;
+  }, { passive: true });
+
+  overlay.addEventListener("touchend", function (e) {
+    var dx = e.changedTouches[0].clientX - touchStartX;
+    var dy = e.changedTouches[0].clientY - touchStartY;
+
+    // Only register horizontal swipes (ignore vertical)
+    if (Math.abs(dx) > 50 && Math.abs(dx) > Math.abs(dy) * 1.5) {
+      if (dx < 0) next();
+      else prev();
+    }
+  }, { passive: true });
 
   // Keyboard navigation
   document.addEventListener("keydown", function (e) {


### PR DESCRIPTION
## Summary
- Swipe left/right on touch devices to navigate between images
- Tap left/right thirds of image to navigate, center to close
- Clickable prev/next arrows on desktop (hidden on touch-only via media query)
- Close button (×) top right
- Nav arrows hide at first/last image

## Test plan
- [ ] Desktop: arrow keys, click arrows, click outside to close
- [ ] Touch: swipe, tap zones, close button
- [ ] Single-image pages: no arrows, no counter

🤖 Generated with [Claude Code](https://claude.com/claude-code)