### PR TITLE
Add trackpad swipe to lightbox

### DIFF
--- a/assets/js/lightbox.js
+++ b/assets/js/lightbox.js
@@ -113,6 +113,28 @@
     }
   }, { passive: true });
 
+  // Trackpad horizontal scroll (two-finger swipe on desktop)
+  var wheelAccum = 0;
+  var wheelTimeout = null;
+
+  overlay.addEventListener("wheel", function (e) {
+    if (currentIndex === -1) return;
+    e.preventDefault();
+
+    wheelAccum += e.deltaX;
+
+    if (wheelTimeout) clearTimeout(wheelTimeout);
+    wheelTimeout = setTimeout(function () { wheelAccum = 0; }, 200);
+
+    if (wheelAccum > 80) {
+      wheelAccum = 0;
+      next();
+    } else if (wheelAccum < -80) {
+      wheelAccum = 0;
+      prev();
+    }
+  }, { passive: false });
+
   // Keyboard navigation
   document.addEventListener("keydown", function (e) {
     if (currentIndex === -1) return;


### PR DESCRIPTION
## Summary
- Handles horizontal wheel events for two-finger trackpad swipe on desktop
- Accumulates deltaX with debounce threshold to avoid over-triggering
- preventDefault stops browser back/forward navigation while lightbox is open

## Test plan
- [ ] Two-finger swipe left/right on trackpad navigates images
- [ ] Doesn't trigger browser back/forward while lightbox is open
- [ ] Touch swipe on mobile still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)