### PR TITLE
Fix shelf normalization convergence with RIAA curve

### DIFF
--- a/assets/tools/riaa-eq.js
+++ b/assets/tools/riaa-eq.js
@@ -60,7 +60,9 @@
   // ============================================================
   // COMPUTE TABLE — always all columns
   // ============================================================
-  var SHELF_NORM = riaaShelf(1000);
+  // Shelf normalization: matches RIAA curve at high frequencies
+  // where the shelf dominates. Accounts for turnover's asymptotic value (T2/T1).
+  var SHELF_NORM = NORM / (T2 / T1);
 
   function computeTable(inverse) {
     var sign = inverse ? -1 : 1;


### PR DESCRIPTION
## Summary
- Shelf normalized to NORM/(T2/T1) so it converges with the RIAA curve above 2 kHz
- Previous normalization to shelf(1kHz) left ~1 dB gap in the treble

## Test plan
- [ ] Shelf curve overlays RIAA dotted reference above 2 kHz
- [ ] Shelf diverges below ~1 kHz where turnover takes over
- [ ] Turnover still correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)