### PR TITLE
Fix shelf plot: remove duplicate SHELF_NORM

### DIFF
--- a/assets/tools/riaa-eq.js
+++ b/assets/tools/riaa-eq.js
@@ -91,9 +91,6 @@
     var sign = inverse ? -1 : 1;
     var traces = [];
 
-    // Shelf normalized to its own value at 1 kHz (0 dB at 1 kHz, rolls off in treble)
-    var SHELF_NORM = riaaShelf(1000);
-
     if (curve === "turnover") {
       // Turnover normalized to full RIAA at 1 kHz + dotted full RIAA reference
       traces.push({


### PR DESCRIPTION
## Summary
- Plot function had local `var SHELF_NORM = riaaShelf(1000)` that shadowed the correct outer `SHELF_NORM = NORM/(T2/T1)`
- Verified: with correct normalization, shelf converges to within 0.26 dB of RIAA at 2 kHz, 0.003 dB at 20 kHz

🤖 Generated with [Claude Code](https://claude.com/claude-code)