### PR TITLE
Add dark theme-color for link preview cards

### DIFF
--- a/_includes/head_custom.html
+++ b/_includes/head_custom.html
@@ -1,0 +1,1 @@
+<meta name="theme-color" content="#1a1e2a">


### PR DESCRIPTION
## Summary
- Adds `<meta name="theme-color" content="#1a1e2a">` via head_custom.html
- Prevents iMessage/Slack from using logo red as link preview background

## Test plan
- [ ] Share a link in iMessage, verify dark background on preview card

🤖 Generated with [Claude Code](https://claude.com/claude-code)