### PR TITLE
Remove spreadsheet references, move About link to bottom

### DIFF
--- a/tools/tonearm-lf-mechanics-about.md
+++ b/tools/tonearm-lf-mechanics-about.md
@@ -7,8 +7,6 @@ nav_exclude: true
 
 This calculator models the low-frequency mechanical behavior of a tonearm-cartridge system. It computes the resonant frequency, damping characteristics, frequency response, transient behavior, and contact force envelope from your cartridge and tonearm specifications.
 
-All outputs have been verified against the original spreadsheet implementation.
-
 ---
 
 ## Input Fields
@@ -134,9 +132,3 @@ where Z = 1000 / dynamic_compliance is the dynamic stiffness and c_critical = 2Â
 The trackability section uses a full transient simulation rather than just steady-state frequency response. This matters because the worst-case contact force occurs during startup â€” the arm is at rest when a modulated groove begins, and the transient overshoot during the first few cycles produces higher peak forces than the eventual steady state.
 
 The simulation solves the equation of motion analytically as the sum of a particular solution (steady-state forced response) and a homogeneous solution (transient decay). Contact force at each timestep includes both the spring force from cantilever deflection and the damping force from cantilever velocity.
-
----
-
-## Source
-
-All formulas have been extracted from the original spreadsheet implementation and verified to match its outputs.

--- a/tools/tonearm-lf-mechanics.md
+++ b/tools/tonearm-lf-mechanics.md
@@ -4,8 +4,6 @@ parent: Tools
 nav_order: 4
 ---
 
-[About this calculator]({{ '/tools/tonearm-lf-mechanics-about' | relative_url }})
-
 <link rel="stylesheet" href="{{ '/assets/tools/tonearm-calculator.css' | relative_url }}">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=IBM+Plex+Sans:wght@400;500&display=swap" rel="stylesheet">
 
@@ -14,4 +12,6 @@ nav_order: 4
 <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.3.1/umd/react.production.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.3.1/umd/react-dom.production.min.js"></script>
 <script src="https://cdn.plot.ly/plotly-2.35.2.min.js"></script>
-<script src="{{ '/assets/tools/tonearm-calculator.js' | relative_url }}"></script>
+<script src="{{ '/assets/tools/tonearm-calculator.js' | relative_url }}">
+
+[About this calculator]({{ '/tools/tonearm-lf-mechanics-about' | relative_url }})</script>


### PR DESCRIPTION
## Summary
- Removes Source section and all spreadsheet references from the About page
- Moves the About link from above the calculator to below it

🤖 Generated with [Claude Code](https://claude.com/claude-code)